### PR TITLE
Removed trailing commas before closing bracket.

### DIFF
--- a/MSBuild.sublime-build
+++ b/MSBuild.sublime-build
@@ -20,7 +20,7 @@
 			"linux":
 			{
 				"cmd": ["xbuild /m $file"]
-			},
+			}
 		},
 		{
 			"cmd": ["msbuild", "$file", "/p:Configuration=Debug"],
@@ -28,7 +28,7 @@
 			"linux":
 			{
 				"cmd": ["xbuild $file /p:Configuration=Debug"]
-			},
+			}
 		},
 		{
 			"cmd": ["msbuild", "$file", "/p:Configuration=Release"],
@@ -36,7 +36,7 @@
 			"linux":
 			{
 				"cmd": ["xbuild $file /p:Configuration=Release"]
-			},
+			}
 		}
 	]
 }


### PR DESCRIPTION
This issue prevented the build in Sublime Text 2 Version 2.0.2, Build 2221
