### PR TITLE
Add sublime_text version selectors

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -7,6 +7,7 @@
 			"labels": ["language syntax", "auto-complete", "build system"],
 			"releases": [
 				{
+					"sublime_text": "*",
 					"details": "https://github.com/tillig/SublimeMSBuild/tags"
 				}
 			]


### PR DESCRIPTION
We require these now due to the confusion it caused in the past
